### PR TITLE
feat(styles): add color variables for statuses

### DIFF
--- a/src/styles/layout-base.css
+++ b/src/styles/layout-base.css
@@ -55,15 +55,14 @@
     --done-border: 52, 91%, 90%;
 
     /* Turquoise */
-    --withheld:  186, 71%, 54%;
+    --withheld: 186, 71%, 54%;
     --withheld-background: 186, 71%, 95%;
     --withheld-border: 186, 71%, 87%;
 
-
     /* Red */
-    --cancelled:0, 84%, 60%;
-    --cancelled-background:0, 84%, 92%;
-    --cancelled-border: 0, 84%, 87%
+    --cancelled: 0, 84%, 60%;
+    --cancelled-background: 0, 84%, 92%;
+    --cancelled-border: 0, 84%, 87%;
   }
 
   .dark {
@@ -118,15 +117,14 @@
     --done-border: 52, 91%, 90%;
 
     /* Turquoise */
-    --withheld:  186, 71%, 54%;
+    --withheld: 186, 71%, 54%;
     --withheld-background: var(--background);
     --withheld-border: 186, 71%, 87%;
 
-
     /* Red */
-    --cancelled:0, 84%, 60%;
+    --cancelled: 0, 84%, 60%;
     --cancelled-background: var(--background);
-    --cancelled-border: 0, 84%, 87%
+    --cancelled-border: 0, 84%, 87%;
   }
 }
 

--- a/src/styles/layout-base.css
+++ b/src/styles/layout-base.css
@@ -38,6 +38,32 @@
     --table-bg-selected: 224, 85%, 84%;
 
     --radius: 0.5rem;
+
+    /* Blue */
+    --usable: 218, 91%, 75%;
+    --usable-background: 218, 91%, 95%;
+    --usable-border: 218, 91%, 90%;
+
+    /* Green */
+    --approved: 126, 26%, 55%;
+    --approved-background: 126, 26%, 95%;
+    --approved-border: 126, 27%, 90%;
+
+    /* Yellow */
+    --done: 52, 91%, 70%;
+    --done-background: 52, 91%, 95%;
+    --done-border: 52, 91%, 90%;
+
+    /* Turquoise */
+    --withheld:  186, 71%, 54%;
+    --withheld-background: 186, 71%, 95%;
+    --withheld-border: 186, 71%, 87%;
+
+
+    /* Red */
+    --cancelled:0, 84%, 60%;
+    --cancelled-background:0, 84%, 92%;
+    --cancelled-border: 0, 84%, 87%
   }
 
   .dark {
@@ -75,6 +101,32 @@
     --table-bg: 240 15% 12%;
     --table-bg-focused: 228, 27%, 98%, 0.05;
     --table-bg-selected: 225, 67%, 87%, 0.3;
+
+    /* Blue */
+    --usable: 218, 91%, 75%;
+    --usable-background: var(--background);
+    --usable-border: 218, 91%, 90%;
+
+    /* Green */
+    --approved: 126, 26%, 55%;
+    --approved-background: var(--background);
+    --approved-border: 126, 27%, 90%;
+
+    /* Yellow */
+    --done: 52, 91%, 70%;
+    --done-background: var(--background);
+    --done-border: 52, 91%, 90%;
+
+    /* Turquoise */
+    --withheld:  186, 71%, 54%;
+    --withheld-background: var(--background);
+    --withheld-border: 186, 71%, 87%;
+
+
+    /* Red */
+    --cancelled:0, 84%, 60%;
+    --cancelled-background: var(--background);
+    --cancelled-border: 0, 84%, 87%
   }
 }
 

--- a/src/styles/preset.ts
+++ b/src/styles/preset.ts
@@ -80,6 +80,31 @@ export default {
           DEFAULT: 'hsl(var(--table-bg))',
           focused: 'hsl(var(--table-bg-focused))',
           selected: 'hsl(var(--table-bg-selected))'
+        },
+        done: {
+          DEFAULT: 'hsl(var(--done))',
+          background: 'hsl(var(--done-background))',
+          border: 'hsl(var(--done-border))'
+        },
+        approved: {
+          DEFAULT: 'hsl(var(--approved))',
+          background: 'hsl(var(--approved-background))',
+          border: 'hsl(var(--approved-border))'
+        },
+        usable: {
+          DEFAULT: 'hsl(var(--usable))',
+          background: 'hsl(var(--usable-background))',
+          border: 'hsl(var(--usable-border))'
+        },
+        withheld: {
+          DEFAULT: 'hsl(var(--withheld))',
+          background: 'hsl(var(--withheld-background))',
+          border: 'hsl(var(--withheld-border))'
+        },
+        cancelled: {
+          DEFAULT: 'hsl(var(--cancelled))',
+          background: 'hsl(var(--cancelled-background))',
+          border: 'hsl(var(--cancelled-border))'
         }
       },
       borderRadius: {


### PR DESCRIPTION
Added new color variables for different statuses in layout-base.css and preset.ts. These include colors for usable, approved, done, withheld, and cancelled statuses. This change improves the clarity of the color scheme for various statuses.