### PR TITLE
Changed styling to elephant styling and added example

### DIFF
--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -7,7 +7,7 @@ import { cva, type VariantProps } from 'class-variance-authority'
 import { cn } from '@/lib/utils'
 
 const labelVariants = cva(
-  'text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70'
+  'text-xs text-muted-foreground font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70'
 )
 
 const Label = React.forwardRef<

--- a/src/showroom/app.tsx
+++ b/src/showroom/app.tsx
@@ -1,6 +1,7 @@
 import { AlertExample } from './components/alert'
 import { ButtonExample } from './components/button'
 import { InputExample } from './components/input'
+import { InputWithLabelExample } from './components/input-with-label'
 import { PopoverExample } from './components/popover'
 import { SheetExample } from './components/sheet'
 import { CommandExample } from './components/command'
@@ -37,6 +38,7 @@ export function App(): JSX.Element {
       <TypographyExample />
       <ButtonExample />
       <InputExample />
+      <InputWithLabelExample />
       <PopoverExample />
       <AlertExample />
       <SheetExample />

--- a/src/showroom/components/input-with-label.tsx
+++ b/src/showroom/components/input-with-label.tsx
@@ -1,0 +1,22 @@
+import { Input } from '@/components/ui/input'
+import { Header } from '../header'
+import { Code } from '../code'
+import { Label } from '@/components/ui/label'
+
+export function InputWithLabelExample(): JSX.Element {
+  return (
+    <>
+      <Header>Input with Label</Header>
+
+      <div>
+        <Label htmlFor='jobtitle'>Job title</Label>
+        <Input placeholder='Job title' />
+      </div>
+      <Code code={`<div>
+  <Label htmlFor='jobtitle'>Job title</Label>
+  <Input placeholder="Job title"/>
+</div>`}
+      />
+    </>
+  )
+}


### PR DESCRIPTION
We are using html label with a lot of special styling throughout elephant-chrome. We should use the commonly styled <Label> from ui.