### PR TITLE
Tooltip: wrap in Portal to escape transform

### DIFF
--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -33,9 +33,11 @@ const Tooltip = ({ content, children }: TooltipProps): React.JSX.Element => (
           {children}
         </span>
       </TooltipPrimitive.Trigger>
-      <TooltipContent>
-        {content}
-      </TooltipContent>
+      <TooltipPrimitive.Portal>
+        <TooltipContent>
+          {content}
+        </TooltipContent>
+      </TooltipPrimitive.Portal>
     </TooltipPrimitive.Root>
   </TooltipPrimitive.Provider>
 )


### PR DESCRIPTION
Radix Tooltip positions itself with position: fixed — normally relative to the screen.
When a Tooltip parent lives inside a Dialog that has a CSS transform. CSS rule: a transformed ancestor hijacks position: fixed so it's relative to that ancestor, not the screen. Tooltip render calculation goes off by the Dialog's offset.
Wrapping it in Portal renders the tooltip at document.body, escaping the transform.